### PR TITLE
fix error thrown when showing `do_next` view with `keep_current[0] == 0`

### DIFF
--- a/etm/model.py
+++ b/etm/model.py
@@ -6474,6 +6474,7 @@ def show_next(db, pinned_list=[], link_list=[], konnect_list=[], timers={}):
 
     tree, row2id = rdict.as_tree(rdict, level=0)
 
+    ctree = None
     if mk_next:
         cdict = NDict(compact=True, width=next_width)
         for row in rows:


### PR DESCRIPTION
In `show_next()`, `ctree` will not be initialized if `!mk_next`, i.e.: https://github.com/dagraham/etm-dgraham/blob/554bf37a7af730fd1ba2c7fe5410189904c9acbc/etm/model.py#L6381

But `show_next()` returns `tree, row2id, ctree`. Therefore, when `keep_current[0] == 0` (and its value is unfortunately exactly 0 by default), it will attempt to return a non-existent variable, and throw an error:

```
Unhandled exception in event loop:
  File "/home/w568w/.local/pipx/venvs/etm-dgraham/lib/python3.11/site-packages/etm/view.py", line 1392, in maybe_alerts
    set_text(dataview.show_active_view())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/w568w/.local/pipx/venvs/etm-dgraham/lib/python3.11/site-packages/etm/model.py", line 2779, in show_active_view
    self.next_view, self.row2id, self.next_txt = show_next(self.db, self.pinned_list, self.link_list, self.konnected, self.timers)
                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/w568w/.local/pipx/venvs/etm-dgraham/lib/python3.11/site-packages/etm/model.py", line 6493, in show_next
    return tree, row2id, ctree
                         ^^^^^

Exception cannot access local variable 'ctree' where it is not associated with a value
```

This PR fixes this by setting `ctree = None` first. It is safe because all callers (for now) has considered the case that `ctree is None`.